### PR TITLE
Feat/generics for execute return

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 coverage
 .ideas
+yarn.lock
+.vscode

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ const flows = new Flows();
 
 //first action
 function first_action(flowData) {
-  console.log('action can do simple staff');
+  console.log('action can do simple stuff');
   const variable = 'all variable should be in the function scope (no state outside an action)';
   return {
     ...flowData,

--- a/release/client/index.d.ts
+++ b/release/client/index.d.ts
@@ -47,6 +47,6 @@ export declare class Flows {
      * @param {string} flowName
      * @param {object} input
      */
-    execute<T extends IActionData, R>(flowName: string, input: T, unsafe?: object): Promise<R>;
+    execute<T extends IActionData, S>(flowName: string, input: T, unsafe?: object): Promise<S>;
 }
 export {};

--- a/release/client/index.d.ts
+++ b/release/client/index.d.ts
@@ -47,6 +47,6 @@ export declare class Flows {
      * @param {string} flowName
      * @param {object} input
      */
-    execute<T extends IActionData>(flowName: string, input: T, unsafe?: object): Promise<T>;
+    execute<T extends IActionData, R>(flowName: string, input: T, unsafe?: object): Promise<R>;
 }
 export {};


### PR DESCRIPTION
When we invoke `flows.execute` while using typescript, not always (almost never) we will have the same response type as the request.
For this use-case i have added a type to the `execute` method generic for serving the purpose of the return type
